### PR TITLE
Fix async_wallpaper API usage in wallpaper bridge

### DIFF
--- a/lib/services/wallpaper_bridge.dart
+++ b/lib/services/wallpaper_bridge.dart
@@ -11,13 +11,13 @@ import 'package:async_wallpaper/async_wallpaper.dart';
 /// Location constants: 1 = home, 2 = lock, 3 = both.
 class AsyncWallpaperBridge {
   static Future<String> setWallpaper(String url, int location) async {
-    final result = await AsyncWallpaper.setWallpaper(
+    final request = WallpaperRequest(
       url: url,
       wallpaperLocation: location,
       goToHome: false,
-      toastDetails: ToastDetails.success(),
-      errorToastDetails: ToastDetails.error(),
     );
+
+    final result = await AsyncWallpaper.setWallpaper(request);
     return result.toString();
   }
 }


### PR DESCRIPTION
### Motivation
- CI was failing because `AsyncWallpaper.setWallpaper` now expects a single `WallpaperRequest` positional argument and the previous call used unsupported named arguments like `toastDetails`, causing `ToastDetails` to be undefined. 
- The bridge must be updated to match the plugin API so the app can compile on mobile platforms.

### Description
- Construct a `WallpaperRequest` with `url`, `wallpaperLocation`, and `goToHome` inside `AsyncWallpaperBridge.setWallpaper`.
- Remove unsupported `toastDetails` and `errorToastDetails` usage that caused undefined symbol errors.
- Call `AsyncWallpaper.setWallpaper(request)` with the `WallpaperRequest` as the required positional argument and return the result as a string.

### Testing
- Attempted `flutter pub get`, which failed because the `flutter` binary is not available in the container, so no Flutter build or pub checks were run. 
- Attempted `dart --version`, which failed because the `dart` binary is not installed, so no local Dart tool validation was possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b289586c94832897c0a2580efe912d)