### PR TITLE
Add Shorebird OTA workflow, document usage, and update wallpaper bridge API call

### DIFF
--- a/.github/workflows/shorebird.yml
+++ b/.github/workflows/shorebird.yml
@@ -1,0 +1,84 @@
+name: Shorebird OTA
+
+on:
+  workflow_dispatch:
+    inputs:
+      command:
+        description: "Shorebird command to run"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - release
+          - patch
+      platform:
+        description: "Target platform"
+        required: true
+        default: android
+        type: choice
+        options:
+          - android
+          - ios
+      release_version:
+        description: "Required for release (example: 1.0.0+1). Ignored for patch."
+        required: false
+        type: string
+
+jobs:
+  shorebird:
+    name: shorebird-${{ github.event.inputs.command }}-${{ github.event.inputs.platform }}
+    runs-on: ubuntu-latest
+    env:
+      SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate auth token
+        run: |
+          if [ -z "$SHOREBIRD_TOKEN" ]; then
+            echo "SHOREBIRD_TOKEN is missing. Add it in repo Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+
+      - name: Setup Java
+        if: github.event.inputs.platform == 'android'
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.41.4'
+          channel: stable
+
+      - name: Install Shorebird
+        run: |
+          curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash
+          echo "$HOME/.shorebird/bin" >> "$GITHUB_PATH"
+
+      - name: Shorebird doctor
+        run: shorebird doctor
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Build Shorebird release
+        if: github.event.inputs.command == 'release'
+        run: |
+          if [ -z "${{ github.event.inputs.release_version }}" ]; then
+            echo "release_version is required when command=release"
+            exit 1
+          fi
+
+          shorebird release ${{ github.event.inputs.platform }} \
+            --flutter-version=3.41.4 \
+            --build-name="${{ github.event.inputs.release_version%%+* }}" \
+            --build-number="${{ github.event.inputs.release_version##*+ }}"
+
+      - name: Build Shorebird patch
+        if: github.event.inputs.command == 'patch'
+        run: |
+          shorebird patch ${{ github.event.inputs.platform }} --flutter-version=3.41.4

--- a/README.md
+++ b/README.md
@@ -83,6 +83,36 @@ flutter build ios
 
 ---
 
+
+## ☁️ OTA Updates with Shorebird
+
+Wallora now includes a GitHub Actions workflow for Shorebird so you can ship **real OTA patches** (Flutter code/assets) without waiting for Play Store / App Store review.
+
+### 1) Add required GitHub secret
+
+In your repository settings, add:
+
+- `SHOREBIRD_TOKEN`: token from `shorebird login:ci`
+
+### 2) Run OTA workflow
+
+Use **Actions → Shorebird OTA → Run workflow** and choose:
+
+- `command`: `release` (first Shorebird build) or `patch` (OTA fix)
+- `platform`: `android` or `ios`
+- `release_version`: required only for `release` (example: `1.2.0+45`)
+
+### 3) Typical flow
+
+1. Publish your first Shorebird-enabled release with `command=release`.
+2. Merge a hotfix to `main`.
+3. Trigger `command=patch` for the same platform.
+4. Existing users receive the patch on next app start (no store re-review for Dart/UI fixes).
+
+> Note: Native Android/iOS code changes still require a store release.
+
+---
+
 ## 🤝 Contributing
 
 Pull requests are welcome.

--- a/lib/services/wallpaper_bridge.dart
+++ b/lib/services/wallpaper_bridge.dart
@@ -11,13 +11,13 @@ import 'package:async_wallpaper/async_wallpaper.dart';
 /// Location constants: 1 = home, 2 = lock, 3 = both.
 class AsyncWallpaperBridge {
   static Future<String> setWallpaper(String url, int location) async {
-    final result = await AsyncWallpaper.setWallpaper(
+    final request = WallpaperRequest(
       url: url,
       wallpaperLocation: location,
       goToHome: false,
-      toastDetails: ToastDetails.success(),
-      errorToastDetails: ToastDetails.error(),
     );
+
+    final result = await AsyncWallpaper.setWallpaper(request);
     return result.toString();
   }
 }


### PR DESCRIPTION
### Motivation

- Enable shipping over-the-air Flutter patches via Shorebird from GitHub Actions. 
- Provide documentation in the `README.md` so maintainers know how to configure and trigger Shorebird workflows. 
- Update the wallpaper bridge to match the `async_wallpaper` API change that now expects a `WallpaperRequest` object. 

### Description

- Add `.github/workflows/shorebird.yml` which exposes a `workflow_dispatch` workflow with `command`, `platform`, and `release_version` inputs and runs `shorebird release` or `shorebird patch` with environment validation and setup steps for Java and Flutter. 
- Install Shorebird in the workflow and validate `SHOREBIRD_TOKEN` from repository secrets before running `shorebird doctor` and build commands. 
- Update `README.md` with a new "OTA Updates with Shorebird" section documenting the required `SHOREBIRD_TOKEN` secret and how to trigger the workflow with `command`, `platform`, and `release_version`. 
- Change `lib/services/wallpaper_bridge.dart` to create a `WallpaperRequest` and pass it to `AsyncWallpaper.setWallpaper(request)`, removing the previous toast parameters. 

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b289586c94832897c0a2580efe912d)